### PR TITLE
feat: add interactive hover effects to PostCard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "tailwindcss": "^3.4.17"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "pagefind": "^1.4.0"
       }
     },
@@ -2890,6 +2891,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.19",
@@ -7024,6 +7041,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -7386,6 +7418,38 @@
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
       "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "pagefind": "^1.4.0"
   }
 }

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -19,7 +19,7 @@ const stats = readingTime(body);
 ---
 
 <article class:list={[
-  'group rounded-xl border overflow-hidden transition-all duration-200 featured-card rangoli-corners',
+  'group rounded-xl border overflow-hidden transition-all duration-200 featured-card rangoli-corners hover:-translate-y-1',
   featured
     ? 'border-terra/30 dark:border-terra-light/20 hover:border-terra dark:hover:border-terra-light hover:shadow-lg shadow-sm'
     : 'border-cream-200 dark:border-night-700 hover:border-terra dark:hover:border-terra-light hover:shadow-md',
@@ -57,13 +57,19 @@ const stats = readingTime(body);
       ]}>
         {description}
       </p>
-      <div class="flex items-center gap-3 mt-3 text-ink-muted dark:text-silk-faint">
-        <span class="inline-flex items-center gap-1.5">
-          <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M16 2v4M8 2v4m-5 4h18"/></svg>
-          <FormattedDate date={date} />
-        </span>
-        <span class="text-cream-400 dark:text-night-700 text-xs select-none">&bull;</span>
-        <span class="font-mono text-xs tabular-nums">{stats.text}</span>
+      <div class="flex items-center justify-between mt-3 text-ink-muted dark:text-silk-faint">
+        <div class="flex items-center gap-3">
+          <span class="inline-flex items-center gap-1.5">
+            <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M16 2v4M8 2v4m-5 4h18"/></svg>
+            <FormattedDate date={date} />
+          </span>
+          <span class="text-cream-400 dark:text-night-700 text-xs select-none">&bull;</span>
+          <span class="font-mono text-xs tabular-nums">{stats.text}</span>
+        </div>
+        <div class="flex items-center text-terra dark:text-terra-light font-medium text-sm transition-transform duration-200 group-hover:translate-x-1 opacity-0 group-hover:opacity-100">
+          <span class="mr-1">Read article</span>
+          <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+        </div>
       </div>
     </div>
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/tests/kolam.spec.ts
+++ b/tests/kolam.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Kolam Border Component', () => {
+  test('should have a flowing CSS animation on the kolam-border element', async ({ page }) => {
+    // Navigate to a page with a kolam-border.
+    await page.goto('http://localhost:4321/');
+
+    // Select the first kolam-border
+    const kolamBorder = page.locator('.kolam-border').first();
+
+    // Expect it to be visible
+    await expect(kolamBorder).toBeVisible();
+
+    // Check if the element has an animation property applied
+    const animation = await kolamBorder.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return style.animationName;
+    });
+
+    // We expect the animation name to be 'flow' or something similar
+    expect(animation).not.toBe('none');
+    expect(animation.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/postcard.spec.ts
+++ b/tests/postcard.spec.ts
@@ -11,6 +11,9 @@ test.describe('PostCard Component', () => {
     // Expect it to have the hover lift class
     await expect(firstArticle).toHaveClass(/hover:-translate-y-1/);
 
+    // Hover the article to trigger opacity transition
+    await firstArticle.hover();
+
     // Expect to find a read article indicator inside it
     const readIndicator = firstArticle.locator('text=Read article');
     await expect(readIndicator).toBeVisible();

--- a/tests/postcard.spec.ts
+++ b/tests/postcard.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('PostCard Component', () => {
+  test('should have a read article indicator and hover animations', async ({ page }) => {
+    // Navigate to a page with a PostCard. Assuming homepage has them.
+    await page.goto('http://localhost:4321/');
+
+    // Select the first article (PostCard)
+    const firstArticle = page.locator('article.group').first();
+
+    // Expect it to have the hover lift class
+    await expect(firstArticle).toHaveClass(/hover:-translate-y-1/);
+
+    // Expect to find a read article indicator inside it
+    const readIndicator = firstArticle.locator('text=Read article');
+    await expect(readIndicator).toBeVisible();
+
+    // The indicator should have a container with the transition classes
+    const indicatorContainer = firstArticle.locator('.group-hover\\:translate-x-1').first();
+    await expect(indicatorContainer).toBeAttached();
+  });
+});


### PR DESCRIPTION
Implemented a visually appealing and interactive hover effect for the `PostCard` component. The entire card now lifts slightly, and a "Read article" indicator fades and slides in on hover. This was done using pure CSS (Tailwind) for optimal performance and simplicity. Followed a Test-Driven Development (TDD) approach by adding Playwright and writing a test suite to verify the new DOM elements and CSS classes.

---
*PR created automatically by Jules for task [16931049170866872219](https://jules.google.com/task/16931049170866872219) started by @jayshah5696*